### PR TITLE
One media stream

### DIFF
--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -20,6 +20,7 @@
     "react-draggable": "^4.4.3",
     "react-router-dom": "^5.2.0",
     "react-scripts": "5.0.1",
+    "video-canvas-screenshot": "^1.0.2",
     "web-vitals": "1.1.1"
   },
   "scripts": {

--- a/react-demo/src/feature/camera/component/CameraManager.scss
+++ b/react-demo/src/feature/camera/component/CameraManager.scss
@@ -1,0 +1,18 @@
+.CameraManager {
+  position: fixed;
+  z-index: 100;
+  top: 0;
+  width: 100%;
+  height: 100vh;
+  max-width: 800px;
+  background: #333;
+  padding: 10px;
+  box-sizing: border-box;
+
+  &__close {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    z-index: 11;
+  }
+}

--- a/react-demo/src/feature/camera/component/CameraManager.tsx
+++ b/react-demo/src/feature/camera/component/CameraManager.tsx
@@ -1,0 +1,35 @@
+import './CameraManager.scss';
+
+import { useState } from 'react';
+import VideoCapture from './VideoCapture';
+import CaptureModal from './CaptureModal';
+import { CloseOutlined } from '@ant-design/icons';
+
+interface CameraManagerProps {
+  onClose: () => void;
+}
+
+const CameraManager = (props: CameraManagerProps) => {
+  const { onClose } = props;
+
+  const [imgSrc, setImgSrc] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const handleCapture = async (imageSrc: string) => {
+    if (imageSrc) {
+      setImgSrc(imageSrc);
+      setOpen(true);
+    }
+  };
+
+  return (
+    <div className="CameraManager">
+      <div className="CameraManager__close">
+        <CloseOutlined style={{ fontSize: '26px', color: '#fff' }} onClick={onClose} />
+      </div>
+      <VideoCapture onCapture={handleCapture} />
+      {imgSrc && <CaptureModal imgSrc={imgSrc} open={open} onClose={() => setOpen(false)} />}
+    </div>
+  );
+}
+export default CameraManager;

--- a/react-demo/src/feature/camera/component/CaptureModal.tsx
+++ b/react-demo/src/feature/camera/component/CaptureModal.tsx
@@ -1,0 +1,18 @@
+import { Modal } from 'antd';
+
+interface Props {
+  imgSrc: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const CaptureModal = (props: Props) => {
+  const { imgSrc, open, onClose } = props;
+
+  return (
+    <Modal title="Captured Image!!" centered open={open} onCancel={onClose} footer={[]} className="CaptureModal">
+      <img style={{ width: '100%' }} src={imgSrc} />
+    </Modal>
+  );
+};
+export default CaptureModal;

--- a/react-demo/src/feature/camera/component/VideoCapture.scss
+++ b/react-demo/src/feature/camera/component/VideoCapture.scss
@@ -1,0 +1,44 @@
+.VideoCapture {
+  position: relative;
+
+  video, canvas {
+    height: 320px;
+    width: auto;
+  }
+
+  &__inner {
+    position: relative;
+    text-align: center;
+    --b: 2px;   /* thickness of the border */
+    --c: white;   /* color of the border */
+    --w: 20px;  /* width of border */
+
+    border: var(--b) solid #0000; /* space for the border */
+    --_g: #0000 90deg,var(--c) 0;
+    --_p: var(--w) var(--w) border-box no-repeat;
+    background:
+      conic-gradient(from 90deg  at top    var(--b) left  var(--b),var(--_g)) 0    0    / var(--_p),
+      conic-gradient(from 180deg at top    var(--b) right var(--b),var(--_g)) 100% 0    / var(--_p),
+      conic-gradient(from 0deg   at bottom var(--b) left  var(--b),var(--_g)) 0    100% / var(--_p),
+      conic-gradient(from -90deg at bottom var(--b) right var(--b),var(--_g)) 100% 100% / var(--_p);
+  }
+
+  button {
+    position: absolute;
+    z-index: 1;
+    bottom: 20px;
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    box-sizing: border-box;
+
+    width: 72px;
+    height: 72px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 8px solid #FFFFFF;
+    border-radius: 50%;
+    box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.12);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+  }
+}

--- a/react-demo/src/feature/camera/component/VideoCapture.tsx
+++ b/react-demo/src/feature/camera/component/VideoCapture.tsx
@@ -1,0 +1,39 @@
+import './VideoCapture.scss';
+
+import { useEffect } from 'react';
+import { captureElementScreenshot } from 'video-canvas-screenshot';
+import { SELF_VIDEO_ID } from '../../video/video-constants';
+
+interface Props {
+  onCapture: (base64Image: string) => void;
+}
+
+const VideoCapture = ({ onCapture }: Props) => {
+  useEffect(() => {
+    const originalParent = document.getElementById('original-parent');
+    const originalCanvas = document.getElementById(SELF_VIDEO_ID);
+    const destination = document.querySelector('.VideoCapture__inner');
+    if (originalCanvas && destination && originalParent) {
+      destination.appendChild(originalCanvas);
+      return () => {
+        originalParent.appendChild(originalCanvas);
+      };
+    }
+  }, []);
+
+  const captureFrame = () => {
+    const canvasElement = document.getElementById(SELF_VIDEO_ID) as HTMLCanvasElement | null;
+    if (!canvasElement) return;
+    captureElementScreenshot(canvasElement, onCapture);
+  };
+
+  return (
+    <div className="VideoCapture">
+      <div className="VideoCapture__inner">
+        <button onClick={captureFrame} />
+      </div>
+    </div>
+  );
+};
+
+export default VideoCapture;

--- a/react-demo/src/feature/video/video-single.tsx
+++ b/react-demo/src/feature/video/video-single.tsx
@@ -19,6 +19,7 @@ import { useAvatarAction } from './hooks/useAvatarAction';
 import { usePrevious } from '../../hooks';
 import './video.scss';
 import { isShallowEqual } from '../../utils/util';
+import CameraManager from '../camera/component/CameraManager';
 
 const VideoContainer: React.FunctionComponent<RouteComponentProps> = (props) => {
   const zmClient = useContext(ZoomContext);
@@ -35,6 +36,7 @@ const VideoContainer: React.FunctionComponent<RouteComponentProps> = (props) => 
   const canvasDimension = useCanvasDimension(mediaStream, videoRef);
   const networkQuality = useNetworkQuality(zmClient);
   const previousCanvasDimension = usePrevious(canvasDimension);
+  const [open, setOpen] = useState(false);
 
   useParticipantsChange(zmClient, (payload) => {
     setParticipants(payload);
@@ -103,10 +105,15 @@ const VideoContainer: React.FunctionComponent<RouteComponentProps> = (props) => 
     }
   }, [mediaStream, activeUser, isVideoDecodeReady, canvasDimension, previousCanvasDimension]);
   const avatarActionState = useAvatarAction(zmClient, activeUser ? [activeUser] : []);
+  const handleClickCamera = () => {
+    mediaStream?.switchCamera('environment');
+    setOpen(true);
+  }
   return (
     <div className="viewport">
       <ShareView ref={shareViewRef} onRecieveSharingChange={setIsRecieveSharing} />
       <div
+        id="original-parent"
         className={classnames('video-container', 'single-video-container', {
           'video-container-in-sharing': isRecieveSharing
         })}
@@ -146,6 +153,10 @@ const VideoContainer: React.FunctionComponent<RouteComponentProps> = (props) => 
           </AvatarActionContext.Provider>
         </div>
       </div>
+      <button style={{ position: 'fixed', zIndex: 10, bottom: 30 }} onClick={handleClickCamera}>
+        Camera
+      </button>
+      {open && <CameraManager onClose={() => setOpen(false)} />}
       <VideoFooter className="video-operations" sharing selfShareCanvas={shareViewRef.current?.selfShareRef} />
     </div>
   );


### PR DESCRIPTION
https://devforum.zoom.us/t/are-there-any-constraints-on-the-mediastream-when-using-the-zoom-video-sdk-for-web/97203/2

There is a problem when using two MediaStreams in an iOS browser.
When using toDataURL to the canvas of the screen showing the Zoom video, in most cases an empty image will be obtained. (contextTeyp: WebGL/preserveDrawingBuffer)

I created a library to take screenshots in such cases.
https://github.com/matometaru/video-canvas-screenshot

This is an implementation using that library with Zoom Video SDK for web.

Requests, advice, and pull requests are also very welcome.

![output](https://github.com/matometaru/videosdk-web-sample/assets/11348058/e0190e4a-eac1-4c99-a2d4-9696b22a6f00)

---------------------------------------

iOSのブラウザで2つのMediaStreamを使うと不具合があります。
Zoomビデオの写っている画面のcanvasをtoDataURLする場合も多くの場合は空の画像が取得されます。（contextTeyp: WebGL/preserveDrawingBuffer）

そのようなケースでスクリーショットが撮るためのライブラリを作りました。
https://github.com/matometaru/video-canvas-screenshot

そのライブラリをZoom Video SDK for webで使った実装です。

要望やアドバイス、プルリクも大歓迎です。

